### PR TITLE
Support specifying user and group id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,10 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get -y --no-install-recommends install \
 		borgbackup openssh-server && apt-get clean && \
-		useradd -s /bin/bash -m borg && \
+		useradd -s /bin/bash -m -U borg && \
 		mkdir /home/borg/.ssh && \
 		chmod 700 /home/borg/.ssh && \
-		chown borg: /home/borg/.ssh && \
+		chown borg:borg /home/borg/.ssh && \
 		mkdir /run/sshd && \
 		rm -f /etc/ssh/ssh_host*key* && \
 		rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/*

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ borg prune --keep-last 100 --keep-weekly 1 (...) borgserver:/clientA/clientA
 ```
 
 
+#### PUID
+Used to set the user id of the `borg` user inside the container. This can be useful when the container has to access resources on the host with a specific user id.
+
+
+#### PGID
+Used to set the group id of the `borg` group inside the container. This can be useful when the container has to access resources on the host with a specific group id.
+
+
 ### Persistent Storages & Client Configuration
 We will need two persistent storage directories for our borgserver to be usefull.
 
@@ -118,6 +126,8 @@ services:
    BORG_SERVE_ARGS: ""
    BORG_APPEND_ONLY: "no"
    BORG_ADMIN: ""
+   PUID: 1000
+   PGID: 1000
 ```
 
 ### ~/.ssh/config for clients

--- a/data/run.sh
+++ b/data/run.sh
@@ -78,6 +78,13 @@ for keyfile in $(find "${SSH_KEY_DIR}/clients" ! -regex '.*/\..*' -a -type f); d
 	cat ${keyfile} >> ${AUTHORIZED_KEYS_PATH}
 done
 
+echo " * Validating structure of generated ${AUTHORIZED_KEYS_PATH}..."
+ERROR=$(ssh-keygen -lf ${AUTHORIZED_KEYS_PATH} 2>&1 >/dev/null)
+if [ $? -ne 0 ]; then
+    echo "ERROR: ${ERROR}"
+    exit 1
+fi
+
 chown -R borg:borg ${BORG_DATA_DIR}
 chown borg:borg ${AUTHORIZED_KEYS_PATH}
 chmod 600 ${AUTHORIZED_KEYS_PATH}


### PR DESCRIPTION
Great script! Some small additions I had to make for my setup, maybe they could be useful for others too?
- Added option to map id for borg user and group, in case they need to be mapped to specific id's on the host for access to resources. The `user` option provided by docker itself, doesn't always work as expected. This trick, also used in all the linuxserver.io containers, always works for me 👍
- Added creation of group so we can explicitly set this id as well when needed
- Add a validity check for the generated authorized_keys file, in case you add something weird to your BORG_SERVE_ARGS (I used `"` w/o escaping in my docker-compose, resulting in an invalid authorized_keys, which took a while to figure out 😋)