### PR TITLE
Split run.sh and add git retrival

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ VOLUME /backup
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get -y --no-install-recommends install \
-		borgbackup openssh-server && apt-get clean && \
+		borgbackup openssh-server git ca-certificates && apt-get clean && \
 		useradd -s /bin/bash -m -U borg && \
 		mkdir /home/borg/.ssh && \
 		chmod 700 /home/borg/.ssh && \
@@ -24,6 +24,9 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 
 COPY ./data/run.sh /run.sh
 COPY ./data/sshd_config /etc/ssh/sshd_config
+COPY ./data/update-ssh-keys.sh /usr/local/bin/
+COPY ./data/create-client-dirs.sh /usr/local/bin/
+COPY ./data/env.sh /usr/local/bin/env.sh
 
 ENTRYPOINT /run.sh
 

--- a/data/create-client-dirs.sh
+++ b/data/create-client-dirs.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -e
+
+source env.sh
+
+function error_exit {
+    echo
+    echo "$@"
+    if [ -e "${AUTHORIZED_KEYS_PATH}.bkp" ]; then
+      echo "Restore authorized_keys backup ${AUTHORIZED_KEYS_PATH}.bkp"
+      mv "${AUTHORIZED_KEYS_PATH}.bkp" "${AUTHORIZED_KEYS_PATH}"
+    fi
+    exit 1
+}
+
+#Trap the killer signals so that we can exit with a good message.
+trap "error_exit 'Received signal SIGHUP'" SIGHUP
+trap "error_exit 'Received signal SIGINT'" SIGINT
+trap "error_exit 'Received signal SIGTERM'" SIGTERM
+
+echo "######################################################"
+echo "* Regenerate borgserver authorized_keys *"
+echo "######################################################"
+
+if [ -e "${AUTHORIZED_KEYS_PATH}" ]; then
+  cp "${AUTHORIZED_KEYS_PATH}" "${AUTHORIZED_KEYS_PATH}.bkp"
+  rm "${AUTHORIZED_KEYS_PATH}"
+fi
+
+# Add every key to borg-users authorized_keys
+for keyfile in $(find "${SSH_KEY_DIR}/clients" ! -regex '.*/\..*' -a -type f); do
+  client_name=$(basename ${keyfile})
+  echo "Add $client_name ssh key"
+  if [ ! -d "${BORG_DATA_DIR}/${client_name}" ]; then
+    mkdir "${BORG_DATA_DIR}/${client_name}" #2>/dev/null
+    echo "  ** Adding client ${client_name} with repo path ${BORG_DATA_DIR}/${client_name}"
+  else
+    echo "Directory ${BORG_DATA_DIR}/${client_name} exists: Nothing to do"
+  fi
+
+  # If client is $BORG_ADMIN unset $client_name, so path restriction equals $BORG_DATA_DIR
+  # Otherwise add --append-only, if enabled
+  borg_cmd=${BORG_CMD}
+  if [ "${client_name}" == "${BORG_ADMIN}" ] ; then
+    echo "   ** Client '${client_name}' is BORG_ADMIN! **"
+    unset client_name
+  elif [ "${BORG_APPEND_ONLY}" == "yes" ] ; then
+    borg_cmd="${BORG_CMD} --append-only"
+  fi
+
+  echo -n "command=\"$(eval echo -n \"${borg_cmd}\")\" " >> ${AUTHORIZED_KEYS_PATH}
+  cat ${keyfile} >> ${AUTHORIZED_KEYS_PATH}
+done
+
+echo " * Validating structure of generated ${AUTHORIZED_KEYS_PATH}..."
+ERROR=$(ssh-keygen -lf ${AUTHORIZED_KEYS_PATH} 2>&1 >/dev/null)
+if [ $? -ne 0 ]; then
+    echo "ERROR: ${ERROR}"
+    exit 1
+fi
+
+chown -R borg:borg ${BORG_DATA_DIR}
+chown borg:borg ${AUTHORIZED_KEYS_PATH}
+chmod 600 ${AUTHORIZED_KEYS_PATH}
+rm -f ${AUTHORIZED_KEYS_PATH}.bkp

--- a/data/env.sh
+++ b/data/env.sh
@@ -1,0 +1,9 @@
+BORG_DATA_DIR=/backup
+SSH_KEY_DIR=/sshkeys
+BORG_CMD='cd ${BORG_DATA_DIR}/${client_name}; borg serve --restrict-to-path ${BORG_DATA_DIR}/${client_name} ${BORG_SERVE_ARGS}'
+AUTHORIZED_KEYS_PATH=/home/borg/.ssh/authorized_keys
+
+# Append only mode?
+BORG_APPEND_ONLY=${BORG_APPEND_ONLY:=no}
+
+export BORG_DATA_DIR SSH_KEY_DIR BORG_CMD AUTHORIZED_KEYS_PATH BORG_APPEND_ONLY

--- a/data/run.sh
+++ b/data/run.sh
@@ -1,19 +1,16 @@
 #!/bin/bash
 # Start Script for docker-borgserver
 
+set -e
+
 PUID=${PUID:-1000}
 PGID=${PGID:-1000}
 
 usermod -o -u "$PUID" borg &>/dev/null
 groupmod -o -g "$PGID" borg &>/dev/null
 
-BORG_DATA_DIR=/backup
-SSH_KEY_DIR=/sshkeys
-BORG_CMD='cd ${BORG_DATA_DIR}/${client_name}; borg serve --restrict-to-path ${BORG_DATA_DIR}/${client_name} ${BORG_SERVE_ARGS}'
-AUTHORIZED_KEYS_PATH=/home/borg/.ssh/authorized_keys
-
-# Append only mode?
-BORG_APPEND_ONLY=${BORG_APPEND_ONLY:=no}
+#source variables
+source env.sh
 
 echo "########################################################"
 echo -n " * Docker BorgServer powered by "
@@ -21,12 +18,24 @@ borg -V
 echo "########################################################"
 echo " * User  id: $(id -u borg)"
 echo " * Group id: $(id -g borg)"
+if [ -z "${BORG_SSHKEYS_REPO}" ] ; then
+  echo "* Pulling keys from ${BORG_SSHKEYS_REPO}"
+fi
 echo "########################################################"
 
 
 # Precheck if BORG_ADMIN is set
 if [ "${BORG_APPEND_ONLY}" == "yes" ] && [ -z "${BORG_ADMIN}" ] ; then
 	echo "WARNING: BORG_APPEND_ONLY is active, but no BORG_ADMIN was specified!"
+fi
+
+# Init the ssh keys directory from a remote git repository
+if [ ! -z "${BORG_SSHKEYS_REPO}" ] ; then
+  if [ ! -d ${SSH_KEY_DIR}/clients ] ; then
+    git clone "${BORG_SSHKEYS_REPO}" ${SSH_KEY_DIR}/clients
+  else
+     /usr/local/bin/update-ssh-keys.sh ${SSH_KEY_DIR}
+  fi
 fi
 
 # Precheck directories & client ssh-keys
@@ -58,36 +67,12 @@ echo "########################################################"
 echo " * Starting SSH-Key import..."
 
 # Add every key to borg-users authorized_keys
-rm ${AUTHORIZED_KEYS_PATH} &>/dev/null
-for keyfile in $(find "${SSH_KEY_DIR}/clients" ! -regex '.*/\..*' -a -type f); do
-    client_name=$(basename ${keyfile})
-    mkdir ${BORG_DATA_DIR}/${client_name} 2>/dev/null
-    echo "  ** Adding client ${client_name} with repo path ${BORG_DATA_DIR}/${client_name}"
-
-	# If client is $BORG_ADMIN unset $client_name, so path restriction equals $BORG_DATA_DIR
-	# Otherwise add --append-only, if enabled
-	borg_cmd=${BORG_CMD}
-	if [ "${client_name}" == "${BORG_ADMIN}" ] ; then
-		echo "   ** Client '${client_name}' is BORG_ADMIN! **"
-		unset client_name
-	elif [ "${BORG_APPEND_ONLY}" == "yes" ] ; then
-		borg_cmd="${BORG_CMD} --append-only"
-	fi
-
-    echo -n "command=\"$(eval echo -n \"${borg_cmd}\")\" " >> ${AUTHORIZED_KEYS_PATH}
-	cat ${keyfile} >> ${AUTHORIZED_KEYS_PATH}
-done
-
-echo " * Validating structure of generated ${AUTHORIZED_KEYS_PATH}..."
-ERROR=$(ssh-keygen -lf ${AUTHORIZED_KEYS_PATH} 2>&1 >/dev/null)
-if [ $? -ne 0 ]; then
-    echo "ERROR: ${ERROR}"
-    exit 1
-fi
-
-chown -R borg:borg ${BORG_DATA_DIR}
-chown borg:borg ${AUTHORIZED_KEYS_PATH}
-chmod 600 ${AUTHORIZED_KEYS_PATH}
+create-client-dirs.sh \
+  "${SSH_KEY_DIR}" \
+  "${BORG_DATA_DIR}" \
+  "${AUTHORIZED_KEYS_PATH}" \
+  "${BORG_CMD}" \
+  "${BORG_APPEND_ONLY}"
 
 echo "########################################################"
 echo " * Init done! Starting SSH-Daemon..."

--- a/data/update-ssh-keys.sh
+++ b/data/update-ssh-keys.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+source env.sh
+
+if [ -d "${SSH_KEY_DIR}/clients/.git" ] ; then
+  cd "${SSH_KEY_DIR}/clients" || exit 0
+  git fetch
+  if ! git diff --quiet remotes/origin/HEAD; then
+    echo "Pull from git repository"
+    git pull
+    create-client-dirs.sh
+  else
+    echo "$0: Nothing to do"
+  fi
+fi


### PR DESCRIPTION
This patch modularize run.sh, adding two new helper scripts and
make it possible to specify a git repository for ssh keys via a
new env variable `BORG_SSHKEYS_REPO`.

the modularization add two new files :
- `env.sh` : define a few envriroment variables
- `create-client-dirs.sh`  : update and create user directories and
  re-create authorized_keys

We also add a new script `update-ssh-keys.sh` to be called regularly
in a cron job to check if the git repository is up-to-date and
eventually adding/removing users.