### PR TITLE
Use Borg version from Debian's buster-backports repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@
 ############################################################
 FROM debian:buster-slim
 
+RUN printf "deb http://deb.debian.org/debian buster-backports main non-free\n#deb-src http://deb.debian.org/debian buster-backports main non-free" > /etc/apt/sources.list.d/backports.list
+
 # Volume for SSH-Keys
 VOLUME /sshkeys
 
@@ -13,7 +15,7 @@ VOLUME /backup
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get -y --no-install-recommends install \
-		borgbackup openssh-server && apt-get clean && \
+		borgbackup/buster-backports openssh-server && apt-get clean && \
 		useradd -s /bin/bash -m -U borg && \
 		mkdir /home/borg/.ssh && \
 		chmod 700 /home/borg/.ssh && \


### PR DESCRIPTION
I noticed that the version of borgbackup that comes with Debian Buster is quite old: 1.1.9 (see https://packages.debian.org/buster/borgbackup). Given that there have been many improvements since then, I decided to upgrade to the version from Debian's backports repository instead. The version available here is 1.1.15 (see https://packages.debian.org/buster-backports/borgbackup).

Note that the version 1.1.9 included with Debian Buster already contains a fix for the index corruption bug that was fixed with 1.1.11 in the regular release (see https://metadata.ftp-master.debian.org/changelogs/main/b/borgbackup/borgbackup_1.1.9-2+deb10u1_changelog).

Not sure if this is of general interest, so feel free not to merge it. Nevertheless, it could be useful for some people so I decided to share it nevertheless.