### PR TITLE
Upgrade: bullseye & borgbackup 1.1.16

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ name: build
 type: kubernetes
 
 steps:
-- name: build-image
+- name: build-bullseye
   image: plugins/kaniko
   settings:
     username:
@@ -13,6 +13,24 @@ steps:
       from_secret: docker_password
     repo: nold360/borgserver
     dockerfile: Dockerfile
+    build_args:
+      - BASE_IMAGE=debian:bullseye-slim
     tags:
+      - latest
       - bullseye
       - 1.1.16
+
+- name: build-buster
+  image: plugins/kaniko
+  settings:
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    repo: nold360/borgserver
+    dockerfile: Dockerfile
+    build_args:
+      - BASE_IMAGE=debian:buster-slim
+    tags:
+      - buster
+      - 1.1.9

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,5 +14,5 @@ steps:
     repo: nold360/borgserver
     dockerfile: Dockerfile
     tags:
-      - latest
-      - buster
+      - bullseye
+      - 1.1.16

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 # Dockerfile to build borgbackup server images
 # Based on Debian
 ############################################################
-FROM debian:bullseye-slim
+ARG BASE_IMAGE=debian:bullseye-slim
+FROM $BASE_IMAGE
 
 # Volume for SSH-Keys
 VOLUME /sshkeys

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile to build borgbackup server images
 # Based on Debian
 ############################################################
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 # Volume for SSH-Keys
 VOLUME /sshkeys

--- a/README.md
+++ b/README.md
@@ -132,3 +132,9 @@ And create your first backup!
 ```
  $ borg create backup:my_first_borg_repo::documents-2017-11-01 /home/user/MyImportentDocs
 ```
+
+## Tags
+
+All images are freshly built every week & published as `nold360/borgserver` with the following tags:
+ - Latest / Stable [borg 1.1.16]: `bullseye`, `1.1.16`, `latest`
+ - Legacy / Buster [borg 1.1.9 ]: `buster`, `1.1.9`

--- a/data/run.sh
+++ b/data/run.sh
@@ -15,9 +15,11 @@ AUTHORIZED_KEYS_PATH=/home/borg/.ssh/authorized_keys
 # Append only mode?
 BORG_APPEND_ONLY=${BORG_APPEND_ONLY:=no}
 
+source /etc/os-release
 echo "########################################################"
 echo -n " * Docker BorgServer powered by "
 borg -V
+echo " * Based on ${PRETTY_NAME}"
 echo "########################################################"
 echo " * User  id: $(id -u borg)"
 echo " * Group id: $(id -g borg)"
@@ -74,7 +76,7 @@ for keyfile in $(find "${SSH_KEY_DIR}/clients" ! -regex '.*/\..*' -a -type f); d
 		borg_cmd="${BORG_CMD} --append-only"
 	fi
 
-    echo -n "command=\"$(eval echo -n \"${borg_cmd}\")\" " >> ${AUTHORIZED_KEYS_PATH}
+    echo -n "restrict,command=\"$(eval echo -n \"${borg_cmd}\")\" " >> ${AUTHORIZED_KEYS_PATH}
 	cat ${keyfile} >> ${AUTHORIZED_KEYS_PATH}
 done
 chmod 0600 "${AUTHORIZED_KEYS_PATH}"

--- a/data/run.sh
+++ b/data/run.sh
@@ -77,6 +77,7 @@ for keyfile in $(find "${SSH_KEY_DIR}/clients" ! -regex '.*/\..*' -a -type f); d
     echo -n "command=\"$(eval echo -n \"${borg_cmd}\")\" " >> ${AUTHORIZED_KEYS_PATH}
 	cat ${keyfile} >> ${AUTHORIZED_KEYS_PATH}
 done
+chmod 0600 "${AUTHORIZED_KEYS_PATH}"
 
 echo " * Validating structure of generated ${AUTHORIZED_KEYS_PATH}..."
 ERROR=$(ssh-keygen -lf ${AUTHORIZED_KEYS_PATH} 2>&1 >/dev/null)


### PR DESCRIPTION
Upgrades the `latest` image to debian bullseye & borgbackup 1.1.16

If you have trouble with the new image, you can use the old one with the tags `buster` or `1.1.9`.

Fixes:  #9 & #11