### PR TITLE
Fix for Issue #21 - container not following SIGTERM signals to close …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 COPY ./data/run.sh /run.sh
 COPY ./data/sshd_config /etc/ssh/sshd_config
 
-ENTRYPOINT /run.sh
-
 # Default SSH-Port for clients
 EXPOSE 22
+
+ENTRYPOINT ["/run.sh"]


### PR DESCRIPTION
if the processes of the container are called under bash -c  because the SIGTERM signals are not passed on to processes.

Apparently
ENTRYPOINT /run.sh
wraps /run.sh in bash -c

and

ENTRYPOINT [“/run.sh”]
doesn’t

Thanks to @andrewcrook #21