### PR TITLE
fix(ci): disable arm build for debian:unstable

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -3,16 +3,19 @@ matrix:
   include:
     - BASE: unstable-slim
       TAGS: '[ "unstable" ]'
+      PLATFORMS: linux/386,linux/amd64
     - BASE: trixie-slim
       TAGS: '[ "trixie", "1.4", "latest" ]'
+      PLATFORMS: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
     - BASE: bookworm-slim
       TAGS: '[ "bookworm", "1.2", "oldstable" ]'
+      PLATFORMS: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
 
 variables:
   - &build-settings
     repo: nold360/borgserver,ghcr.io/nold360/borgserver
     tags: ${TAGS}
-    platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
+    platforms: ${PLATFORMS}
     build_args:
       BASE_IMAGE: debian:${BASE}
 


### PR DESCRIPTION
Fixes #36

arm builds deactivated since they somehow fail. 